### PR TITLE
Locked Device Orientation in PortraitUp Mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,11 +20,10 @@ void main() async {
   await ActivityController.initialize();
   UnsplashAPIService.loadenv();
   WidgetsFlutterBinding.ensureInitialized();
-  SystemChrome.setPreferredOrientations([               // Locks the device orientation in PortraitUp only.
+  await SystemChrome.setPreferredOrientations([               // Locks the device orientation in PortraitUp only.
     DeviceOrientation.portraitUp                        // This method is not applicable on iPad when multitasking is enabled.
-  ]).then((_) {
-    runApp(MyApp());
-  });
+  ]);
+  runApp(MyApp());
 }
 
 /// MyApp is the most Parent widget and initialises the main route.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart' as c;
 import 'package:flutter/widgets.dart';
 import 'package:hive/hive.dart';
+import 'package:flutter/services.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 
 // Files
@@ -18,7 +19,12 @@ void main() async {
   await Hive.openBox<Activity>(activityBoxName);
   await ActivityController.initialize();
   UnsplashAPIService.loadenv();
-  runApp(MyApp());
+  WidgetsFlutterBinding.ensureInitialized();
+  SystemChrome.setPreferredOrientations([               // Locks the device orientation in PortraitUp only.
+    DeviceOrientation.portraitUp                        // This method is not applicable on iPad when multitasking is enabled.
+  ]).then((_) {
+    runApp(MyApp());
+  });
 }
 
 /// MyApp is the most Parent widget and initialises the main route.


### PR DESCRIPTION
Fixed #118.
Locked the complete app in portraitUp mode using setPreferredOrientations method in main().

```
SystemChrome.setPreferredOrientations([               // Locks the device orientation in PortraitUp only.
    DeviceOrientation.portraitUp                        // This method is not applicable on iPad when multitasking is enabled.
  ]).then((_) {
    runApp(MyApp());
  });
```