### PR TITLE
Implemented the correct way of tabBuilder for CupertinoTabBar

### DIFF
--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -35,9 +35,17 @@ class _HomeState extends State<Home> {
 
   Widget tabBuilder(BuildContext context, int index) {
     if (BottomTabOption.values[index] == BottomTabOption.home) {
-      return HomePage();
+      return c.CupertinoTabView(
+        builder: (context){
+          return HomePage();
+        },
+      );
     } else {
-      return ProfilePage();
+      return c.CupertinoTabView(
+        builder: (context){
+          return ProfilePage();
+        },
+      );
     }
   }
 


### PR DESCRIPTION
Changed following 
```
return HomePage();
```
to 
```
return c.CupertinoTabView(
        builder: (context){
          return HomePage();
        },
      );
```
Correct BuildContext should be passed to Widget we want to be rendered using BottomNavigationTabs using CupertinoTabView.