### PR TITLE
Solved Navigation Hero Bug.

### DIFF
--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -125,6 +125,8 @@ class _HomePageState extends State<HomePage> {
         c.CupertinoPageScaffold(
           backgroundColor: Color(0x00000000),
           navigationBar: c.CupertinoNavigationBar(
+            heroTag: 'HomePage',
+            transitionBetweenRoutes: false,
             backgroundColor: Color(0x00000000),
             leading: PreferanceButton(),
             trailing: YearButton(),

--- a/lib/screens/year_page.dart
+++ b/lib/screens/year_page.dart
@@ -24,6 +24,8 @@ class _YearPageState extends State<YearPage> {
         context,
       ),
       navigationBar: c.CupertinoNavigationBar(
+        heroTag: 'YearPage',
+        transitionBetweenRoutes: false,
         backgroundColor: c.CupertinoDynamicColor.resolve(
           c.CupertinoColors.systemBackground,
           context,


### PR DESCRIPTION
Fixes #120 .
The bug was due to same usage of default hero tag in both of CupertinoNavigationBar in ```home_page.dart``` and ```year_page.dart``` .  