### PR TITLE
Action sheet

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -43,5 +43,5 @@
 
     "editor.suggestOnTriggerCharacters": true
   },
-  "cmake.configureOnOpen": false
+  "cmake.configureOnOpen": false,
 }

--- a/lib/screens/activity_page.dart
+++ b/lib/screens/activity_page.dart
@@ -22,6 +22,24 @@ class ActivityPage extends StatelessWidget {
     await Navigator.of(context).popAndPushNamed(ActivityRouteInitializer.route, arguments: activity);
   }
 
+  void actionSheet(BuildContext context) async {
+    await c.showCupertinoModalPopup(
+        context: context,
+        builder: (c.BuildContext context) => c.CupertinoActionSheet(
+              actions: <c.CupertinoActionSheetAction>[
+                c.CupertinoActionSheetAction(onPressed: () {}, child: const c.Text('Share')),
+                c.CupertinoActionSheetAction(onPressed: () => onEdit(context), child: const c.Text('Edit')),
+                c.CupertinoActionSheetAction(onPressed: () {}, child: const c.Text('Add to Favorite')),
+              ],
+              cancelButton: c.CupertinoActionSheetAction(
+                onPressed: () {
+                  Navigator.pop(context);
+                },
+                child: const c.Text('Cancel'),
+              ),
+            ));
+  }
+
   @override
   Widget build(BuildContext context) {
     return c.CupertinoPageScaffold(
@@ -36,7 +54,7 @@ class ActivityPage extends StatelessWidget {
         ),
         middle: const Text('Activity'),
         trailing: GestureDetector(
-          onTap: () => onEdit(context),
+          onTap: () => actionSheet(context),
           child: const c.Icon(Icons.more_horiz_rounded),
         ),
         border: null,

--- a/lib/screens/activity_page.dart
+++ b/lib/screens/activity_page.dart
@@ -37,10 +37,7 @@ class ActivityPage extends StatelessWidget {
         middle: const Text('Activity'),
         trailing: GestureDetector(
           onTap: () => onEdit(context),
-          child: Text(
-            'Edit',
-            style: c.CupertinoTheme.of(context).textTheme.navActionTextStyle,
-          ),
+          child: const c.Icon(Icons.more_horiz_rounded),
         ),
         border: null,
       ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -112,7 +112,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -456,7 +456,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   meta:
     dependency: transitive
     description:
@@ -671,7 +671,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   timezone:
     dependency: transitive
     description:
@@ -741,7 +741,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   version_manipulation:
     dependency: transitive
     description:


### PR DESCRIPTION
- [x] In ActivityPage add a "vertical 3 dot icon" on the top right corner of the screen.

- [x] On tap to this icon, open CupertinoActionSheet with following tiles:

- [ ] #244 

- [ ] "Edit" on tap -> Navigate to ActivityEditSheet (just more the functionality that was on the top right corner previously)

- [ ] #245 

- [ ] "Cancel" ontap -> navigator.pop (as explained in CupertinoActionSheet docs