### PR TITLE
Removed About Developer Option

### DIFF
--- a/lib/presentation/screen/setting_screen.dart
+++ b/lib/presentation/screen/setting_screen.dart
@@ -43,10 +43,6 @@ class SettingsScreen extends StatelessWidget
                 subtitle: 'Know who’s using starbook app',
                 onTap: () => UrlLauncher().starBookCommunity()),
             CustomTile(
-                title: 'About Developer',
-                subtitle: 'Amazing developers behind starbook',
-                onTap: () => UrlLauncher().developer()),
-            CustomTile(
                 title: 'Privacy & Terms',
                 subtitle: 'All your data and personal info terms',
                 onTap: () => UrlLauncher().privacyPolicy()),


### PR DESCRIPTION
closes issue #464 
Removed the About Developer option in the settings screen.